### PR TITLE
Feature/results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ yarn-debug.log*
 yarn-error.log*
 .vscode/
 .aws-sam/
-.env
+.env.local
 
 # Editor directories and files
 .idea

--- a/src/pages/Result.vue
+++ b/src/pages/Result.vue
@@ -82,7 +82,7 @@ export default {
     data(){
         return {
           loading: true,
-          resources: {},
+          resources: [],
           noResults: {},
           endpoint: process.env.VUE_APP_API_ENDPOINT
         }

--- a/src/pages/Result.vue
+++ b/src/pages/Result.vue
@@ -1,38 +1,38 @@
 <template>
   <div>
-    <div v-if="loading">
-      <br/>
-      <h2>Loading...</h2>
-      <br/>
+    <div v-if="loading" >
+      <v-skeleton-loader type="card" v-for="n in 5" :key="n"/>
     </div>
-    <div v-else-if="filteredList.length === 0">
-      <h1>{{ noResults.title }}</h1>
-      <v-col v-html="noResults.content"></v-col>
-      <v-btn id="btn-restart-assessment" @click="startAgain">Start again</v-btn>
-    </div>
-    <v-container v-else id="container-results">
-      <v-row v-for="resource in filteredList " :key="resource.name">
-        <v-col>
-            <v-card class="mx-auto resource">
-              <v-card-text>
-                <p class="display-1 text--primary"> {{ resource.doc.name }}</p>
-                <div class="text--primary"> 
-                  <span v-html="resource.doc.content"></span>
-                </div>
-                <div> 
-                  <v-chip v-for="iTag in resource.doc.includeTags" :key="iTag" class="ma-2" color="green" text-color="white">
-                    {{ iTag }}
-                  </v-chip>
-                  <v-chip v-for="eTag in resource.doc.excludeTags" :key="eTag" class="ma-2" color="red" text-color="white">
-                    {{ eTag }}
-                  </v-chip>
-                </div>
-              </v-card-text>
-            </v-card>
-          </v-col>
-        </v-row>
-      </v-container>
-    </div>
+    <div v-else>
+      <div v-if="filteredList.length === 0">
+        <h1>{{ noResults.title }}</h1>
+        <v-col v-html="noResults.content"></v-col>
+        <v-btn id="btn-restart-assessment" @click="startAgain">Start again</v-btn>
+      </div>
+      <v-container v-else id="container-results">
+        <v-row v-for="resource in filteredList " :key="resource.name">
+          <v-col>
+              <v-card class="mx-auto resource">
+                <v-card-text>
+                  <p class="display-1 text--primary"> {{ resource.doc.name }}</p>
+                  <div class="text--primary"> 
+                    <span v-html="resource.doc.content"></span>
+                  </div>
+                  <div> 
+                    <v-chip v-for="iTag in resource.doc.includeTags" :key="iTag" class="ma-2" color="green" text-color="white">
+                      {{ iTag }}
+                    </v-chip>
+                    <v-chip v-for="eTag in resource.doc.excludeTags" :key="eTag" class="ma-2" color="red" text-color="white">
+                      {{ eTag }}
+                    </v-chip>
+                  </div>
+                </v-card-text>
+              </v-card>
+            </v-col>
+          </v-row>
+        </v-container>
+      </div>
+  </div>
 </template>
 
 <script>
@@ -43,17 +43,14 @@ export default {
     self: this,
     components: {},
     created() {
-      fetch(this.endpoint + '/resources')
-        .then(x =>x.json())
-        .then(x => {this.resources = x})
-        .catch((err)=>{console.log(err)})
-      fetch(this.endpoint + '/config/positive-outcome')
-        .then(x=>x.json())
-        .then(x=> this.noResults = x)
-        .catch((err)=>{console.log(err)})
-        .finally(() => {
-          this.loading = false
-        })
+      Promise.all([
+        fetch(this.endpoint + '/resources')
+          .then(x =>x.json())
+          .then(x => {this.resources = x}),
+        fetch(this.endpoint + '/config/positive-outcome')
+          .then(x=>x.json())
+          .then(x=> this.noResults = x)]
+      ).then(() => {this.loading = false})
     },
     props: ["responses"],
     methods: {


### PR DESCRIPTION
Fixed an issue where the default results page would briefly display before the results themselves. It will now wait until all the resources are loaded and display some skeletons while they're waiting. However, we should really be improving this process so that it checks results and only then gets default results content