### PR TITLE
Feature/select

### DIFF
--- a/src/pages/Select.vue
+++ b/src/pages/Select.vue
@@ -16,8 +16,8 @@
                         <v-row>
                             <v-col>
                                 <item
+                                    key="categories_item0"
                                     ref="categories_item0"
-                                    v-show="!loading && !showJourneys"
                                     title="Where do you need support?"
                                     subtitle="Please select one or more"
                                     :items="categories"
@@ -52,8 +52,8 @@
                         <v-row>
                             <v-col>
                                 <item
+                                    key="journeys_item0"
                                     ref="journeys_item0"
-                                    v-show="!loading && showJourneys"
                                     title="Where do you need support?"
                                     subtitle="Please select one or more"
                                     :items="possibleJourneys"
@@ -168,7 +168,7 @@ export default {
             if (selected && !this.$refs.categories.validate()) {
                 return false;
             }
-            this.categoriesSelected = selected;
+            this.categoriesSelected = !!selected;
         },
         doFocus(){
             window.scrollTo(0,0);

--- a/tests/test_scdip.py
+++ b/tests/test_scdip.py
@@ -295,6 +295,38 @@ class ScdipTests(SetupTest):
     def test_select(self):
         self.page_home()
         self.page_select()
+    
+    #Test that categories are mandatory
+    def test_select_mandatory_categories(self):
+        self.page_home()
+        self.confirm_categories()
+        parent_elem = WebDriverWait(self.browser, 10).until(
+            EC.presence_of_element_located((By.CSS_SELECTOR, "#parent-selection")),
+            'Failed to locate category selection'
+        )
+        v_input = parent_elem.find_element_by_css_selector('.v-input')
+        classes = v_input.get_attribute('class')
+        is_error = "error--text" in classes
+        self.assertTrue(is_error, "Failed to detect error style")
+        message = v_input.find_element_by_css_selector('.v-messages__message')
+        self.assertEqual(message.text, "Please select at least one category.")
+
+    #Test that journies are mandatory
+    def test_select_mandatory_journies(self):
+        self.page_home()
+        self.fill_category_input()
+        self.confirm_categories()
+        self.confirm_journies()
+        parent_elem =  WebDriverWait(self.browser, 10).until(
+            EC.presence_of_element_located((By.CSS_SELECTOR, "#journey-selection")),
+            'Failed to locate category selection'
+        )
+        v_input = parent_elem.find_element_by_css_selector('.v-input')
+        classes = v_input.get_attribute('class')
+        is_error = "error--text" in classes
+        self.assertTrue(is_error, "Failed to detect error style")
+        message = v_input.find_element_by_css_selector('.v-messages__message')
+        self.assertEqual(message.text, "Please select at least one journey.")
 
     #Test that resources are rendered
     def test_resources_render(self):


### PR DESCRIPTION
#16455 Not allowed to pass through parent and area selection [Player]

Fixes issue that allowed internal data for the item component was leaking between categories and journeys, interfering with validation.
Added negative tests