### PR TITLE
Bug #16748 [Player] Next/Finish button not correctly determined if items on following page are hidden by include/exlcude tags

### DIFF
--- a/src/pages/Assess.vue
+++ b/src/pages/Assess.vue
@@ -64,7 +64,7 @@
                             name="btn-finish"
                             @click="finish"
                         >
-                            Finish
+                            Next
                         </v-btn>
                         <v-btn
                             v-else
@@ -128,7 +128,8 @@ export default {
             return Math.round((this.pageIdx / this.displayPages.length) * 100);
         },
         finished() {
-            return this.pageIdx >= this.displayPages.length;
+            return !this.displayPages.slice(this.pageIdx)
+                .filter(page => page.items && page.items.length).length;
         },
         displayPages() {
             // Arguably, this should filter the pages but it'd make progress tracking harder

--- a/src/pages/Assess.vue
+++ b/src/pages/Assess.vue
@@ -128,8 +128,7 @@ export default {
             return Math.round((this.pageIdx / this.displayPages.length) * 100);
         },
         finished() {
-            return !this.displayPages.slice(this.pageIdx)
-                .filter(page => page.items && page.items.length).length;
+            return !this.displayPages.slice(this.pageIdx).some(page => page.items && page.items.length);
         },
         displayPages() {
             // Arguably, this should filter the pages but it'd make progress tracking harder


### PR DESCRIPTION
set finished to true if no remaining pages have items